### PR TITLE
Refactor: Remove Overlay permission from default list

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ on:
 
 
 env:
-  VERSION_NAME: 0.0.5  # Update this value for each release
+  VERSION_NAME: 0.0.6  # Update this value for each release
 
 jobs:
   release:

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,9 +19,6 @@
 
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
-    <!-- For displaying an Activity over other apps/lock screen -->
-    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
-
     <!-- Permissions for scheduling exact alarms -->
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
 

--- a/triggerx/src/main/java/com/meticha/triggerx/permission/TriggerXPermissionComposable.kt
+++ b/triggerx/src/main/java/com/meticha/triggerx/permission/TriggerXPermissionComposable.kt
@@ -55,7 +55,6 @@ fun rememberAppPermissionState(): PermissionState {
         addAll(
             listOf(
                 PermissionType.ALARM,
-                PermissionType.OVERLAY,
                 PermissionType.BATTERY_OPTIMIZATION,
                 PermissionType.NOTIFICATION
             )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Removed the requirement for overlay permission, so the app will no longer request permission to display over other apps.
  - Updated the app version to 0.0.6 for the latest release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->