### PR TITLE
Feat: Add overlay permission guidance and persistence

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
       - main
 
 env:
-  VERSION_NAME: 0.0.7  # Update this value for each release
+  VERSION_NAME: 0.0.8  # Update this value for each release
 
 jobs:
   release:

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
 
     <!-- Permissions for scheduling exact alarms -->
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
 
     <application
         android:name=".TriggerXApplication"

--- a/app/src/main/java/com/meticha/triggerxexample/home/HomeScreen.kt
+++ b/app/src/main/java/com/meticha/triggerxexample/home/HomeScreen.kt
@@ -24,19 +24,22 @@ import androidx.compose.material3.ElevatedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.meticha.triggerx.permission.rememberAppPermissionState
+import kotlinx.coroutines.launch
 
 @Composable
 fun HomeScreen(
-    viewModel: HomeViewModel = hiltViewModel()
+    viewModel: HomeViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
     val permissionState = rememberAppPermissionState()
+    val coroutines = rememberCoroutineScope()
 
 
     Scaffold { paddingValues ->
@@ -50,17 +53,19 @@ fun HomeScreen(
         ) {
             ElevatedButton(
                 onClick = {
-                    if (permissionState.allRequiredGranted()) {
-                        Toast.makeText(
-                            context,
-                            "Scheduled for 1 minute. Now you can close the App and chill",
-                            Toast.LENGTH_SHORT
-                        ).show()
-                        viewModel.scheduleOneMinuteAlarm(
-                            context
-                        )
-                    } else {
-                        permissionState.requestPermission()
+                    coroutines.launch {
+                        if (permissionState.allRequiredGranted()) {
+                            Toast.makeText(
+                                context,
+                                "Scheduled for 1 minute. Now you can close the App and chill",
+                                Toast.LENGTH_SHORT
+                            ).show()
+                            viewModel.scheduleOneMinuteAlarm(
+                                context
+                            )
+                        } else {
+                            permissionState.requestPermission()
+                        }
                     }
                 }
             ) {

--- a/app/src/main/java/com/meticha/triggerxexample/home/HomeViewModel.kt
+++ b/app/src/main/java/com/meticha/triggerxexample/home/HomeViewModel.kt
@@ -18,8 +18,10 @@ package com.meticha.triggerxexample.home
 import android.content.Context
 import android.util.Log
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.meticha.triggerx.TriggerXAlarmScheduler
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import java.util.Calendar
 import javax.inject.Inject
 
@@ -32,17 +34,24 @@ class HomeViewModel @Inject constructor() : ViewModel() {
 
     private val appAlarmManager: TriggerXAlarmScheduler = TriggerXAlarmScheduler()
 
-    fun scheduleOneMinuteAlarm(context: Context): Boolean {
+    fun scheduleOneMinuteAlarm(context: Context) {
         val triggerTime = Calendar.getInstance().apply {
             add(Calendar.MINUTE, 1)
         }.timeInMillis
 
         Log.i(TAG, "Attempting to schedule alarm for 1 minute from now ($triggerTime)")
-        return appAlarmManager.scheduleAlarm(context, triggerTime, "MEETING", 1)
+        viewModelScope.launch {
+            appAlarmManager.scheduleAlarm(
+                context,
+                triggerTime,
+                "MEETING",
+                1
+            )
+        }
 
     }
 
     fun cancelCurrentAlarm(context: Context, id: Int) {
-        appAlarmManager.cancelAlarm(context, id)
+        viewModelScope.launch { appAlarmManager.cancelAlarm(context, id) }
     }
 }

--- a/triggerx/src/main/java/com/meticha/triggerx/permission/PermissionLifeCycleCheckEffect.kt
+++ b/triggerx/src/main/java/com/meticha/triggerx/permission/PermissionLifeCycleCheckEffect.kt
@@ -17,10 +17,12 @@ package com.meticha.triggerx.permission
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.meticha.triggerx.logger.LoggerConfig
+import kotlinx.coroutines.launch
 
 
 /**
@@ -40,12 +42,12 @@ internal fun PermissionLifeCycleCheckEffect(
     permissionState: PermissionState,
     lifecycleEvent: Lifecycle.Event = Lifecycle.Event.ON_RESUME,
 ) {
-
+    val core = rememberCoroutineScope()
     val observer = LifecycleEventObserver { _, event ->
         LoggerConfig.logger.d("Event: $event")
         if (event == lifecycleEvent) {
             if (permissionState.resumedFromSettings) {
-                permissionState.requestPermission()
+                core.launch { permissionState.requestPermission() }
                 permissionState.resumedFromSettings = false
             }
         }

--- a/triggerx/src/main/java/com/meticha/triggerx/permission/TriggerXPermissionComposable.kt
+++ b/triggerx/src/main/java/com/meticha/triggerx/permission/TriggerXPermissionComposable.kt
@@ -154,7 +154,7 @@ private fun ShowPermissionGuidanceDialog(
                           "Please go to your phone's Settings -> Apps -> Manage Apps (or similar) -> Find '$appName' -> " +
                           "Other permissions (or App permissions) -> And ensure 'Display pop-up windows while running in the background' " +
                           "(or a similar sounding option like 'Start in background') is ENABLED.\n\n" +
-                          "This reminder is shown once if you click 'Understood'.",
+                          "This reminder is shown once if you click 'Acknowledge'.",
                 onDismiss = {
                     permissionState.showPermissionGuidanceDialog = false
                     coroutineScope.launch {

--- a/triggerx/src/main/java/com/meticha/triggerx/permission/TriggerXPermissionComposable.kt
+++ b/triggerx/src/main/java/com/meticha/triggerx/permission/TriggerXPermissionComposable.kt
@@ -27,8 +27,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.window.DialogProperties
 import com.meticha.triggerx.permission.AlarmPermissionManager.isGranted
-import com.meticha.triggerx.preference.TriggerXPermissionFlagManager
+import com.meticha.triggerx.preference.TriggerXManualPermissionStatusManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import java.lang.ref.WeakReference
@@ -157,7 +158,7 @@ private fun ShowPermissionGuidanceDialog(
                 onDismiss = {
                     permissionState.showPermissionGuidanceDialog = false
                     coroutineScope.launch {
-                        TriggerXPermissionFlagManager.savePermissionDialogResponse(
+                        TriggerXManualPermissionStatusManager.savePermissionDialogResponse(
                             context,
                             permissionType = permission,
                             acknowledged = false
@@ -167,7 +168,7 @@ private fun ShowPermissionGuidanceDialog(
                 onConfirm = {
                     permissionState.showPermissionGuidanceDialog = false
                     coroutineScope.launch {
-                        TriggerXPermissionFlagManager.savePermissionDialogResponse(
+                        TriggerXManualPermissionStatusManager.savePermissionDialogResponse(
                             context,
                             permissionType = permission,
                             acknowledged = true
@@ -197,6 +198,10 @@ internal fun ShowManualPermissionDialog(
 ) {
     AlertDialog(
         onDismissRequest = onDismiss,
+        properties = DialogProperties(
+            dismissOnClickOutside = false,
+            dismissOnBackPress = true,
+        ),
         title = { Text("Permission Required") },
         text = {
             Text(
@@ -206,6 +211,11 @@ internal fun ShowManualPermissionDialog(
         confirmButton = {
             Button(onClick = onConfirm) {
                 Text("Acknowledge")
+            }
+        },
+        dismissButton = {
+            Button(onClick = onDismiss) {
+                Text("Later")
             }
         }
     )

--- a/triggerx/src/main/java/com/meticha/triggerx/permission/TriggerXPermissionComposable.kt
+++ b/triggerx/src/main/java/com/meticha/triggerx/permission/TriggerXPermissionComposable.kt
@@ -16,6 +16,7 @@
 package com.meticha.triggerx.permission
 
 import android.annotation.SuppressLint
+import android.content.Context
 import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -24,8 +25,12 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalContext
 import com.meticha.triggerx.permission.AlarmPermissionManager.isGranted
+import com.meticha.triggerx.preference.TriggerXPermissionFlagManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import java.lang.ref.WeakReference
 
 
@@ -56,21 +61,25 @@ fun rememberAppPermissionState(): PermissionState {
             listOf(
                 PermissionType.ALARM,
                 PermissionType.BATTERY_OPTIMIZATION,
-                PermissionType.NOTIFICATION
+                PermissionType.NOTIFICATION,
+                PermissionType.OVERLAY,
             )
         )
         if (Build.MANUFACTURER.equals("Xiaomi", true)) {
             add(PermissionType.LOCK_SCREEN)
         }
+//        if (Build.MANUFACTURER.equals("oneplus", true)) {
+        add(PermissionType.OVERLAY_WHILE_BACKGROUND)
+//        }
     }
 
     val context = LocalContext.current
 
     val permissionState = remember(permissions) { PermissionState(permissions) }
+    val coroutineScope = rememberCoroutineScope()
 
     // Provide context access through composable scope
     permissionState.contextRef = WeakReference(context)
-
 
     // Handle lifecycle events
     PermissionLifeCycleCheckEffect(
@@ -81,39 +90,97 @@ fun rememberAppPermissionState(): PermissionState {
     permissionState.launcher = rememberLauncherForActivityResult(
         ActivityResultContracts.StartActivityForResult()
     ) { result ->
-        when {
-            isGranted(context, permissionState.currentPermission!!) -> {
-                permissionState.allRequiredGranted()
-                permissionState.next()
-            }
+        coroutineScope.launch {
+            when {
+                isGranted(context, permissionState.currentPermission!!) -> {
+                    permissionState.allRequiredGranted()
+                    permissionState.next()
+                }
 
-            else -> handlePermissionDenial(
-                permissionState
-            )
+                else                                                    -> handlePermissionDenial(
+                    permissionState
+                )
+            }
         }
     }
 
     // Display permission rationale popup if needed
     permissionState.currentPermission?.let { permission ->
         when {
-            permissionState.showRationalePopUp -> {
+            permission.isManualPermissionType && permissionState.showPermissionGuidanceDialog -> {
+                ShowPermissionGuidanceDialog(
+                    permission = permission,
+                    permissionState = permissionState,
+                    context = context,
+                    coroutineScope = coroutineScope
+                )
+            }
+
+            permissionState.showRationalePopUp                                                -> {
                 ShowPopup(
                     message = "Permissions are required to proceed further",
                     onConfirm = {
                         permissionState.showRationalePopUp = false
-                        permissionState.requestPermission()
+                        coroutineScope.launch { permissionState.requestPermission() }
                     },
                     onDismiss = {
                         permissionState.showRationalePopUp = false
                     }
                 )
             }
+
         }
     }
+
 
     return permissionState
 }
 
+@Composable
+private fun ShowPermissionGuidanceDialog(
+    context: Context,
+    permission: PermissionType,
+    permissionState: PermissionState,
+    coroutineScope: CoroutineScope,
+) {
+    when (permission) {
+        PermissionType.OVERLAY_WHILE_BACKGROUND -> {
+            val appName =
+                remember { context.applicationInfo.loadLabel(context.packageManager).toString() }
+            ShowManualPermissionDialog(
+                message = "For alarms to reliably appear when the app is in the background, " +
+                          "'$appName' needs an additional permission on some phones (like Xiaomi, Oppo, Vivo, etc.).\n\n" +
+                          "Please go to your phone's Settings -> Apps -> Manage Apps (or similar) -> Find '$appName' -> " +
+                          "Other permissions (or App permissions) -> And ensure 'Display pop-up windows while running in the background' " +
+                          "(or a similar sounding option like 'Start in background') is ENABLED.\n\n" +
+                          "This reminder is shown once if you click 'Understood'.",
+                onDismiss = {
+                    permissionState.showPermissionGuidanceDialog = false
+                    coroutineScope.launch {
+                        TriggerXPermissionFlagManager.savePermissionDialogResponse(
+                            context,
+                            permissionType = permission,
+                            acknowledged = false
+                        )
+                    }
+                },
+                onConfirm = {
+                    permissionState.showPermissionGuidanceDialog = false
+                    coroutineScope.launch {
+                        TriggerXPermissionFlagManager.savePermissionDialogResponse(
+                            context,
+                            permissionType = permission,
+                            acknowledged = true
+                        )
+                        permissionState.next()
+                    }
+                },
+            )
+        }
+
+        else                                    -> {}
+    }
+}
 
 /**
  * Handles permission denial, showing appropriate UI based on denial context
@@ -122,6 +189,27 @@ private fun handlePermissionDenial(permissionState: PermissionState) {
     permissionState.showRationalePopUp = true
 }
 
+@Composable
+internal fun ShowManualPermissionDialog(
+    message: String,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Permission Required") },
+        text = {
+            Text(
+                message
+            )
+        },
+        confirmButton = {
+            Button(onClick = onConfirm) {
+                Text("Acknowledge")
+            }
+        }
+    )
+}
 
 
 /**
@@ -165,3 +253,4 @@ internal fun ShowPopup(
         }
     )
 }
+

--- a/triggerx/src/main/java/com/meticha/triggerx/permission/TriggerXPermissionComposable.kt
+++ b/triggerx/src/main/java/com/meticha/triggerx/permission/TriggerXPermissionComposable.kt
@@ -68,9 +68,9 @@ fun rememberAppPermissionState(): PermissionState {
         if (Build.MANUFACTURER.equals("Xiaomi", true)) {
             add(PermissionType.LOCK_SCREEN)
         }
-//        if (Build.MANUFACTURER.equals("oneplus", true)) {
-        add(PermissionType.OVERLAY_WHILE_BACKGROUND)
-//        }
+        if (Build.MANUFACTURER.equals("oneplus", true)) {
+            add(PermissionType.OVERLAY_WHILE_BACKGROUND)
+        }
     }
 
     val context = LocalContext.current

--- a/triggerx/src/main/java/com/meticha/triggerx/permission/TriggerXPermissionManager.kt
+++ b/triggerx/src/main/java/com/meticha/triggerx/permission/TriggerXPermissionManager.kt
@@ -27,29 +27,13 @@ import android.os.Build
 import android.provider.Settings
 import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.activity.result.ActivityResult
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
-import com.meticha.triggerx.preference.TriggerXPermissionFlagManager
+import com.meticha.triggerx.preference.TriggerXManualPermissionStatusManager
 import kotlinx.coroutines.flow.first
 import java.lang.ref.WeakReference
 import java.lang.reflect.Method
@@ -140,7 +124,7 @@ internal object AlarmPermissionManager {
     }
 
     suspend fun isOverlayBackgroundPermissionEnabled(context: Context): Boolean =
-        TriggerXPermissionFlagManager.isPermissionDialogAcknowledged(
+        TriggerXManualPermissionStatusManager.isPermissionDialogAcknowledged(
             context,
             permissionType = PermissionType.OVERLAY_WHILE_BACKGROUND
         ).first()
@@ -245,52 +229,6 @@ enum class PermissionType(val isManualPermissionType: Boolean = false) {
     OVERLAY_WHILE_BACKGROUND(isManualPermissionType = true),
 
 }
-
-@Composable
-private fun OverlayPermissionGuidanceDialog(
-    appName: String,
-    onUnderstoodClick: () -> Unit,
-) {
-    MaterialTheme { // Using a default MaterialTheme wrapper
-        Card(
-            shape = RoundedCornerShape(16.dp),
-            modifier = Modifier.padding(16.dp), // Outer padding for the card itself in relation to dialog window
-            elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
-        ) {
-            Column(
-                modifier = Modifier
-                    .padding(24.dp) // Inner padding for the content
-                    .fillMaxWidth()
-            ) {
-                Text(
-                    text = "Important: Enable Background Pop-ups",
-                    style = MaterialTheme.typography.titleLarge,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onSurface
-                )
-                Spacer(modifier = Modifier.height(16.dp))
-                Text(
-                    text = "For alarms to reliably appear when the app is in the background, " +
-                           "'$appName' needs an additional permission on some phones (like Xiaomi, Oppo, Vivo, etc.)." +
-                           "Please go to your phone's Settings -> Apps -> Manage Apps (or similar) -> Find '$appName' -> " +
-                           "Other permissions (or App permissions) -> And ensure 'Display pop-up windows while running in the background' " +
-                           "(or a similar sounding option like 'Start in background') is ENABLED." +
-                           "This reminder is shown only once if you click 'Understood'.",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                Spacer(modifier = Modifier.height(24.dp))
-                Button(
-                    onClick = onUnderstoodClick,
-                    modifier = Modifier.align(Alignment.End)
-                ) {
-                    Text("Understood")
-                }
-            }
-        }
-    }
-}
-
 
 /**
  * Manages the state of permission requests and their UI flows, particularly for a list

--- a/triggerx/src/main/java/com/meticha/triggerx/preference/TriggerXAlarmIdManager.kt
+++ b/triggerx/src/main/java/com/meticha/triggerx/preference/TriggerXAlarmIdManager.kt
@@ -18,9 +18,12 @@ package com.meticha.triggerx.preference
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import com.meticha.triggerx.permission.PermissionType
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 
@@ -59,4 +62,31 @@ internal object TriggerXAlarmIdManager {
             settings.remove(KEY_ALARM_IDS)
         }
     }
+}
+
+internal object TriggerXPermissionFlagManager {
+
+    suspend fun savePermissionDialogResponse(
+        context: Context,
+        permissionType: PermissionType,
+        acknowledged: Boolean,
+    ) {
+        val key = getPreferenceKeyForType(permissionType)
+        context.dataStore.edit { settings ->
+            settings[key] = acknowledged
+        }
+    }
+
+    fun isPermissionDialogAcknowledged(context: Context, permissionType: PermissionType): Flow<Boolean> {
+        val key = getPreferenceKeyForType(permissionType)
+        return context.dataStore.data
+            .map { preferences ->
+                preferences[key] ?: false
+            }
+    }
+
+    private fun getPreferenceKeyForType(permissionType: PermissionType): Preferences.Key<Boolean> {
+        return booleanPreferencesKey("permission_dialog_shown_${permissionType.name}")
+    }
+
 }

--- a/triggerx/src/main/java/com/meticha/triggerx/preference/TriggerXAlarmIdManager.kt
+++ b/triggerx/src/main/java/com/meticha/triggerx/preference/TriggerXAlarmIdManager.kt
@@ -18,12 +18,9 @@ package com.meticha.triggerx.preference
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
-import com.meticha.triggerx.permission.PermissionType
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 
@@ -62,31 +59,4 @@ internal object TriggerXAlarmIdManager {
             settings.remove(KEY_ALARM_IDS)
         }
     }
-}
-
-internal object TriggerXPermissionFlagManager {
-
-    suspend fun savePermissionDialogResponse(
-        context: Context,
-        permissionType: PermissionType,
-        acknowledged: Boolean,
-    ) {
-        val key = getPreferenceKeyForType(permissionType)
-        context.dataStore.edit { settings ->
-            settings[key] = acknowledged
-        }
-    }
-
-    fun isPermissionDialogAcknowledged(context: Context, permissionType: PermissionType): Flow<Boolean> {
-        val key = getPreferenceKeyForType(permissionType)
-        return context.dataStore.data
-            .map { preferences ->
-                preferences[key] ?: false
-            }
-    }
-
-    private fun getPreferenceKeyForType(permissionType: PermissionType): Preferences.Key<Boolean> {
-        return booleanPreferencesKey("permission_dialog_shown_${permissionType.name}")
-    }
-
 }

--- a/triggerx/src/main/java/com/meticha/triggerx/preference/TriggerXManualPermissionStatusManager.kt
+++ b/triggerx/src/main/java/com/meticha/triggerx/preference/TriggerXManualPermissionStatusManager.kt
@@ -1,3 +1,18 @@
+/*
+ * Designed and developed by MetichaHQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.meticha.triggerx.preference
 
 import android.content.Context

--- a/triggerx/src/main/java/com/meticha/triggerx/preference/TriggerXManualPermissionStatusManager.kt
+++ b/triggerx/src/main/java/com/meticha/triggerx/preference/TriggerXManualPermissionStatusManager.kt
@@ -1,0 +1,43 @@
+package com.meticha.triggerx.preference
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStore
+import com.meticha.triggerx.permission.PermissionType
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "triggerx_permission_status")
+
+internal object TriggerXManualPermissionStatusManager {
+
+    suspend fun savePermissionDialogResponse(
+        context: Context,
+        permissionType: PermissionType,
+        acknowledged: Boolean,
+    ) {
+        val key = getPreferenceKeyForType(permissionType)
+        context.dataStore.edit { settings ->
+            settings[key] = acknowledged
+        }
+    }
+
+    fun isPermissionDialogAcknowledged(
+        context: Context,
+        permissionType: PermissionType,
+    ): Flow<Boolean> {
+        val key = getPreferenceKeyForType(permissionType)
+        return context.dataStore.data
+            .map { preferences ->
+                preferences[key] ?: false
+            }
+    }
+
+    private fun getPreferenceKeyForType(permissionType: PermissionType): Preferences.Key<Boolean> {
+        return booleanPreferencesKey("permission_dialog_shown_${permissionType.name}")
+    }
+
+}


### PR DESCRIPTION
This commit introduces a dialog to guide users on enabling "display pop-up windows while running in the background" permission, particularly for devices like Xiaomi, Oppo, and Vivo. The user's acknowledgment of this dialog is now persisted using DataStore.

Key changes:
- **triggerx/src/main/java/com/meticha/triggerx/permission/TriggerXPermissionComposable.kt**:
    - Added `PermissionType.OVERLAY` and `PermissionType.OVERLAY_WHILE_BACKGROUND` to the default `permissions` list.
    - Implemented `ShowPermissionGuidanceDialog` to display specific instructions for `OVERLAY_WHILE_BACKGROUND`.
    - Integrated `TriggerXPermissionFlagManager` to save and check the acknowledgment state of the guidance dialog.
    - Permission requests and dialog showings are now launched within a `CoroutineScope`.
    - Added `ShowManualPermissionDialog` composable for generic manual permission guidance.
- **triggerx/src/main/java/com/meticha/triggerx/permission/TriggerXPermissionManager.kt**:
    - Added `OVERLAY_WHILE_BACKGROUND` to `PermissionType` enum, marking it as a `isManualPermissionType`.
    - Implemented `isOverlayBackgroundPermissionEnabled` to check acknowledgment status via `TriggerXPermissionFlagManager`.
    - `isGranted` now handles `OVERLAY_WHILE_BACKGROUND` by checking its acknowledgment status.
    - `createPermissionIntent` now returns `null` for `PermissionType`s that are manually configured by the user (like `OVERLAY_WHILE_BACKGROUND`).
    - Added `OverlayPermissionGuidanceDialog` composable (though currently unused directly, parts of its logic are adapted elsewhere).
    - `PermissionState.requestPermission` now checks for `isManualPermissionType` to show `showPermissionGuidanceDialog` instead of launching an intent.
    - `PermissionState.allRequiredGranted` and `PermissionState.isGranted` are now suspend functions.
    - `PermissionState.next` is now a suspend function.
- **app/src/main/java/com/meticha/triggerxexample/home/HomeScreen.kt**:
    - Permission requests (`permissionState.requestPermission()`) and checks (`permissionState.allRequiredGranted()`) are now called within a `CoroutineScope`.
- **triggerx/src/main/java/com/meticha/triggerx/permission/PermissionLifeCycleCheckEffect.kt**:
    - `permissionState.requestPermission()` is now launched within a `CoroutineScope` in the lifecycle observer.
- **app/src/main/java/com/meticha/triggerxexample/home/HomeViewModel.kt**:
    - `scheduleOneMinuteAlarm` and `cancelCurrentAlarm` now launch their operations within `viewModelScope`.
- **app/src/main/AndroidManifest.xml**:
    - Added `android.permission.SYSTEM_ALERT_WINDOW` permission.
- **triggerx/src/main/java/com/meticha/triggerx/preference/TriggerXAlarmIdManager.kt**:
    - Added `TriggerXPermissionFlagManager` object to save and retrieve boolean flags for permission dialog acknowledgments using DataStore.
    - Implemented `savePermissionDialogResponse` and `isPermissionDialogAcknowledged`.

---
name: Pull Request
about: Propose changes to TriggerX
title: ''
labels: ''
assignees: ''
---

## Description

Please include a summary of the change and which issue is fixed (if any).
e.g., Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Android Version(s):
* Device(s)/Emulator(s):
* TriggerXExample app variant:


## Screenshots (if applicable)

| Before | After |
| ------ | ----- |
|        |       |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for new manual permission types, including overlay permissions that require user guidance.
  * Introduced user-facing dialogs with detailed instructions for enabling permissions that cannot be requested via standard system prompts.
  * Enhanced permission handling UI to better guide users through manual permission processes.

* **Improvements**
  * Permission checks and requests are now handled asynchronously, improving app responsiveness.
  * Permission state and dialog acknowledgment are now persisted for a smoother user experience.
  * Alarm scheduling and cancellation operations are now performed asynchronously to enhance performance.

* **Chores**
  * Updated app permissions to include overlay window support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->